### PR TITLE
Add FastAPI wrapper and plugin description

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
     - `version_id`: The ID of the version to retrieve objects from
     - `property_path`: The dot-notation path to the property (e.g., "elements.0.name")
 
+## HTTP Wrapper & ChatGPT Plugin
+
+To expose the MCP functions over HTTP run:
+```bash
+uvicorn http_wrapper:app --reload
+```
+
+The server hosts `openapi.yaml` at `/openapi.yaml` and the plugin manifest at `/.well-known/ai-plugin.json`. Make these files reachable by ChatGPT using a public URL.
+
 ## Troubleshooting
 
 - If you encounter authentication issues, make sure your Speckle token is valid and has the necessary permissions

--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Speckle MCP Plugin",
+  "name_for_model": "speckle_mcp_plugin",
+  "description_for_human": "Interact with Speckle projects and models via HTTP.",
+  "description_for_model": "Expose Speckle MCP functions as HTTP endpoints.",
+  "auth": {
+    "type": "none"
+  },
+  "api": {
+    "type": "openapi",
+    "url": "http://localhost:8000/openapi.yaml",
+    "is_user_authenticated": false
+  },
+  "logo_url": "http://localhost:8000/logo.png",
+  "contact_email": "support@example.com",
+  "legal_info_url": "http://localhost:8000/legal"
+}

--- a/http_wrapper.py
+++ b/http_wrapper.py
@@ -1,0 +1,59 @@
+from fastapi import FastAPI, Response
+from fastapi.responses import PlainTextResponse, JSONResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
+import json
+
+import speckle_server as server
+
+app = FastAPI(title="Speckle MCP HTTP Wrapper")
+
+# Serve plugin files
+@app.get("/openapi.yaml", include_in_schema=False)
+async def openapi_spec():
+    return FileResponse("openapi.yaml", media_type="text/yaml")
+
+@app.get("/.well-known/ai-plugin.json", include_in_schema=False)
+async def plugin_manifest():
+    return FileResponse("ai-plugin.json", media_type="application/json")
+
+# Helper to parse JSON if possible
+def maybe_json(result: str) -> Response:
+    try:
+        data = json.loads(result)
+        return JSONResponse(data)
+    except Exception:
+        return PlainTextResponse(result)
+
+@app.get("/projects")
+async def http_list_projects(limit: int = 20):
+    result = await server.list_projects(limit)
+    return maybe_json(result)
+
+@app.get("/projects/{project_id}")
+async def http_get_project_details(project_id: str, limit: int = 20):
+    result = await server.get_project_details(project_id, limit)
+    return maybe_json(result)
+
+@app.get("/projects/search")
+async def http_search_projects(query: str):
+    result = await server.search_projects(query)
+    return maybe_json(result)
+
+@app.get("/projects/{project_id}/models/{model_id}/versions")
+async def http_get_model_versions(project_id: str, model_id: str, limit: int = 20):
+    result = await server.get_model_versions(project_id, model_id, limit)
+    return maybe_json(result)
+
+@app.get("/projects/{project_id}/versions/{version_id}/objects")
+async def http_get_version_objects(project_id: str, version_id: str, include_children: bool = False):
+    result = await server.get_version_objects(project_id, version_id, include_children)
+    return maybe_json(result)
+
+@app.get("/projects/{project_id}/versions/{version_id}/query")
+async def http_query_object_properties(project_id: str, version_id: str, property_path: str):
+    result = await server.query_object_properties(project_id, version_id, property_path)
+    return maybe_json(result)
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,141 @@
+openapi: 3.1.0
+info:
+  title: Speckle MCP Plugin API
+  version: "1.0"
+servers:
+  - url: http://localhost:8000
+paths:
+  /projects:
+    get:
+      summary: List available projects
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+          required: false
+      responses:
+        '200':
+          description: Project list
+          content:
+            text/plain:
+              schema:
+                type: string
+  /projects/{project_id}:
+    get:
+      summary: Get details for a project
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+          required: false
+      responses:
+        '200':
+          description: Project details
+          content:
+            text/plain:
+              schema:
+                type: string
+  /projects/search:
+    get:
+      summary: Search projects by name or description
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Search results
+          content:
+            text/plain:
+              schema:
+                type: string
+  /projects/{project_id}/models/{model_id}/versions:
+    get:
+      summary: List versions for a model
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: model_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+          required: false
+      responses:
+        '200':
+          description: Versions list
+          content:
+            text/plain:
+              schema:
+                type: string
+  /projects/{project_id}/versions/{version_id}/objects:
+    get:
+      summary: Retrieve objects for a version
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: include_children
+          in: query
+          schema:
+            type: boolean
+          required: false
+      responses:
+        '200':
+          description: Version objects
+          content:
+            application/json:
+              schema:
+                type: object
+  /projects/{project_id}/versions/{version_id}/query:
+    get:
+      summary: Query properties from a version
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: version_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: property_path
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Property value
+          content:
+            application/json:
+              schema:
+                type: object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn>=0.34.0",
     "asyncio>=3.4.3",
     "ipykernel>=6.29.5",
     "mcp>=1.3.0",


### PR DESCRIPTION
## Summary
- implement `http_wrapper.py` exposing Speckle MCP tools as HTTP routes
- describe endpoints in `openapi.yaml`
- add ChatGPT plugin manifest `ai-plugin.json`
- document launching the wrapper in README
- include FastAPI and uvicorn in the project dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ddafcbd48325909b9bdbbe296d9a