### PR TITLE
Add cursor pagination support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,18 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
 - `list_projects`: Lists all accessible Speckle projects
   - Parameters:
     - `limit` (optional): Maximum number of projects to retrieve (default: 20)
+    - `cursor` (optional): Pagination cursor returned from a previous request
 
 - `get_project_details`: Retrieves detailed information about a specific project
   - Parameters:
     - `project_id`: The ID of the Speckle project to retrieve
     - `limit` (optional): Maximum number of models to retrieve (default: 20)
+    - `cursor` (optional): Pagination cursor returned from a previous request
 
 - `search_projects`: Searches for projects by name or description
   - Parameters:
     - `query`: The search term to look for in project names and descriptions
+    - `cursor` (optional): Pagination cursor returned from a previous request
 
 ### Models
 
@@ -103,6 +106,7 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
     - `project_id`: The ID of the Speckle project
     - `model_id`: The ID of the model to retrieve versions for
     - `limit` (optional): Maximum number of versions to retrieve (default: 20)
+    - `cursor` (optional): Pagination cursor returned from a previous request
 
 ### Objects
 
@@ -111,12 +115,22 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
     - `project_id`: The ID of the Speckle project
     - `version_id`: The ID of the version to retrieve objects from
     - `include_children` (optional): Whether to include children objects in the response (default: false)
+    - `cursor` (optional): Pagination cursor returned from a previous request
 
 - `query_object_properties`: Queries specific properties from objects in a version
   - Parameters:
     - `project_id`: The ID of the Speckle project
     - `version_id`: The ID of the version to retrieve objects from
     - `property_path`: The dot-notation path to the property (e.g., "elements.0.name")
+
+### Pagination Example
+
+Use the `cursor` parameter to request additional pages from the HTTP wrapper:
+
+```bash
+curl "http://localhost:8000/projects?limit=5"        # first page
+curl "http://localhost:8000/projects?limit=5&cursor=<cursor_token>"  # next page
+```
 
 ## HTTP Wrapper & ChatGPT Plugin
 

--- a/http_wrapper.py
+++ b/http_wrapper.py
@@ -25,28 +25,40 @@ def maybe_json(result: str) -> Response:
         return PlainTextResponse(result)
 
 @app.get("/projects")
-async def http_list_projects(limit: int = 20):
-    result = await server.list_projects(limit)
+async def http_list_projects(limit: int = 20, cursor: str | None = None):
+    result = await server.list_projects(limit, cursor)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}")
-async def http_get_project_details(project_id: str, limit: int = 20):
-    result = await server.get_project_details(project_id, limit)
+async def http_get_project_details(
+    project_id: str, limit: int = 20, cursor: str | None = None
+):
+    result = await server.get_project_details(project_id, limit, cursor)
     return maybe_json(result)
 
 @app.get("/projects/search")
-async def http_search_projects(query: str):
-    result = await server.search_projects(query)
+async def http_search_projects(query: str, cursor: str | None = None):
+    result = await server.search_projects(query, cursor)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}/models/{model_id}/versions")
-async def http_get_model_versions(project_id: str, model_id: str, limit: int = 20):
-    result = await server.get_model_versions(project_id, model_id, limit)
+async def http_get_model_versions(
+    project_id: str,
+    model_id: str,
+    limit: int = 20,
+    cursor: str | None = None,
+):
+    result = await server.get_model_versions(project_id, model_id, limit, cursor)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}/versions/{version_id}/objects")
-async def http_get_version_objects(project_id: str, version_id: str, include_children: bool = False):
-    result = await server.get_version_objects(project_id, version_id, include_children)
+async def http_get_version_objects(
+    project_id: str,
+    version_id: str,
+    include_children: bool = False,
+    cursor: str | None = None,
+):
+    result = await server.get_version_objects(project_id, version_id, include_children, cursor)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}/versions/{version_id}/query")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,6 +15,11 @@ paths:
             type: integer
             default: 20
           required: false
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: Project list
@@ -37,6 +42,11 @@ paths:
             type: integer
             default: 20
           required: false
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: Project details
@@ -53,6 +63,11 @@ paths:
           required: true
           schema:
             type: string
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: Search results
@@ -80,6 +95,11 @@ paths:
             type: integer
             default: 20
           required: false
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: Versions list
@@ -105,6 +125,11 @@ paths:
           in: query
           schema:
             type: boolean
+          required: false
+        - name: cursor
+          in: query
+          schema:
+            type: string
           required: false
       responses:
         '200':


### PR DESCRIPTION
## Summary
- add optional `cursor` parameter to server functions
- expose cursor parameter in HTTP routes
- document cursor query param in the OpenAPI spec
- explain pagination and example usage in README

## Testing
- `python -m py_compile speckle_server.py http_wrapper.py`

------
https://chatgpt.com/codex/tasks/task_e_68422612f5348325a2ed400262341b2d