### PR TITLE
Fix objects schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -144,10 +144,15 @@ paths:
               schema:
                 type: object
                 properties:
-                  objects:
-                    type: array
-                    items:
-                      type: object
+                  version_id:
+                    type: string
+                  object_id:
+                    type: string
+                  created_at:
+                    type: string
+                    format: date-time
+                  data:
+                    type: object
   /projects/{project_id}/versions/{version_id}/query:
     get:
       operationId: queryVersionObjects


### PR DESCRIPTION
## Summary
- update schema for getVersionObjects in openapi docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68424b1491048325ad8ea4f3e7902ffd