### PR TITLE
Fix get_project_details HTTP call

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
   - Parameters:
     - `project_id`: The ID of the Speckle project to retrieve
     - `limit` (optional): Maximum number of models to retrieve (default: 20)
-    - `cursor` (optional): Pagination cursor returned from a previous request
 
 - `search_projects`: Searches for projects by name or description
   - Parameters:

--- a/http_wrapper.py
+++ b/http_wrapper.py
@@ -30,10 +30,9 @@ async def http_list_projects(limit: int = 20, cursor: str | None = None):
     return maybe_json(result)
 
 @app.get("/projects/{project_id}")
-async def http_get_project_details(
-    project_id: str, limit: int = 20, cursor: str | None = None
-):
-    result = await server.get_project_details(project_id, limit, cursor)
+async def http_get_project_details(project_id: str, limit: int = 20):
+    """HTTP endpoint to retrieve detailed information for a project."""
+    result = await server.get_project_details(project_id, limit)
     return maybe_json(result)
 
 @app.get("/projects/search")


### PR DESCRIPTION
## Summary
- remove unsupported `cursor` argument from `http_get_project_details`
- update documentation to match the new parameter list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425098e7308325bbce152ba5c45187