### PR TITLE
Remove cursor params

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
 - `list_projects`: Lists all accessible Speckle projects
   - Parameters:
     - `limit` (optional): Maximum number of projects to retrieve (default: 20)
-    - `cursor` (optional): Pagination cursor returned from a previous request
 
 - `get_project_details`: Retrieves detailed information about a specific project
   - Parameters:
@@ -96,7 +95,6 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
 - `search_projects`: Searches for projects by name or description
   - Parameters:
     - `query`: The search term to look for in project names and descriptions
-    - `cursor` (optional): Pagination cursor returned from a previous request
 
 ### Models
 
@@ -105,7 +103,6 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
     - `project_id`: The ID of the Speckle project
     - `model_id`: The ID of the model to retrieve versions for
     - `limit` (optional): Maximum number of versions to retrieve (default: 20)
-    - `cursor` (optional): Pagination cursor returned from a previous request
 
 ### Objects
 
@@ -114,22 +111,12 @@ Replace `/path/to/speckle-mcp` with the actual path to the directory containing 
     - `project_id`: The ID of the Speckle project
     - `version_id`: The ID of the version to retrieve objects from
     - `include_children` (optional): Whether to include children objects in the response (default: false)
-    - `cursor` (optional): Pagination cursor returned from a previous request
 
 - `query_object_properties`: Queries specific properties from objects in a version
   - Parameters:
     - `project_id`: The ID of the Speckle project
     - `version_id`: The ID of the version to retrieve objects from
     - `property_path`: The dot-notation path to the property (e.g., "elements.0.name")
-
-### Pagination Example
-
-Use the `cursor` parameter to request additional pages from the HTTP wrapper:
-
-```bash
-curl "http://localhost:8000/projects?limit=5"        # first page
-curl "http://localhost:8000/projects?limit=5&cursor=<cursor_token>"  # next page
-```
 
 ## HTTP Wrapper & ChatGPT Plugin
 

--- a/http_wrapper.py
+++ b/http_wrapper.py
@@ -25,8 +25,8 @@ def maybe_json(result: str) -> Response:
         return PlainTextResponse(result)
 
 @app.get("/projects")
-async def http_list_projects(limit: int = 20, cursor: str | None = None):
-    result = await server.list_projects(limit, cursor)
+async def http_list_projects(limit: int = 20):
+    result = await server.list_projects(limit)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}")
@@ -36,8 +36,8 @@ async def http_get_project_details(project_id: str, limit: int = 20):
     return maybe_json(result)
 
 @app.get("/projects/search")
-async def http_search_projects(query: str, cursor: str | None = None):
-    result = await server.search_projects(query, cursor)
+async def http_search_projects(query: str):
+    result = await server.search_projects(query)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}/models/{model_id}/versions")
@@ -45,9 +45,8 @@ async def http_get_model_versions(
     project_id: str,
     model_id: str,
     limit: int = 20,
-    cursor: str | None = None,
 ):
-    result = await server.get_model_versions(project_id, model_id, limit, cursor)
+    result = await server.get_model_versions(project_id, model_id, limit)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}/versions/{version_id}/objects")
@@ -55,9 +54,8 @@ async def http_get_version_objects(
     project_id: str,
     version_id: str,
     include_children: bool = False,
-    cursor: str | None = None,
 ):
-    result = await server.get_version_objects(project_id, version_id, include_children, cursor)
+    result = await server.get_version_objects(project_id, version_id, include_children)
     return maybe_json(result)
 
 @app.get("/projects/{project_id}/versions/{version_id}/query")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,11 +56,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: cursor
-          in: query
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: Search results
@@ -89,11 +84,6 @@ paths:
             type: integer
             default: 20
           required: false
-        - name: cursor
-          in: query
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: Versions list
@@ -120,11 +110,6 @@ paths:
           in: query
           schema:
             type: boolean
-          required: false
-        - name: cursor
-          in: query
-          schema:
-            type: string
           required: false
       responses:
         '200':

--- a/speckle_server.py
+++ b/speckle_server.py
@@ -439,20 +439,17 @@ def get_speckle_client() -> SpeckleClient:
 
 @mcp.tool()
 @handle_exceptions
-async def list_projects(limit: int = 20, cursor: str | None = None) -> str:
+async def list_projects(limit: int = 20) -> str:
     """List all projects accessible with the configured Speckle token.
 
     Args:
         limit: Maximum number of projects to retrieve (default: 20)
-        cursor: Pagination cursor returned from a previous call
     """
     client = get_speckle_client()
 
     # Get the current user's projects
-    logger.info(
-        f"Retrieving user projects (limit: {limit}, cursor: {cursor})"
-    )
-    projects_collection = client.active_user.get_projects(limit=limit, cursor=cursor)
+    logger.info(f"Retrieving user projects (limit: {limit})")
+    projects_collection = client.active_user.get_projects(limit=limit)
     
     if not projects_collection or not projects_collection.items:
         logger.info("No projects found for the configured Speckle account")
@@ -549,25 +546,22 @@ async def get_project_details(
 
 @mcp.tool()
 @handle_exceptions
-async def search_projects(query: str, cursor: str | None = None) -> str:
+async def search_projects(query: str) -> str:
     """Search for Speckle projects by name or description.
     
     Args:
         query: The search term to look for in project names and descriptions
-        cursor: Pagination cursor returned from a previous call
     """
     client = get_speckle_client()
     
     # Use the built-in search_projects functionality of SpeckleClient
-    logger.info(
-        f"Searching for projects with query: '{query}' (cursor: {cursor})"
-    )
+    logger.info(f"Searching for projects with query: '{query}'")
     
     # Create a filter with the search term
     filter = UserProjectsFilter(search=query)
     
     # Get projects using the filter
-    projects_collection = client.active_user.get_projects(filter=filter, cursor=cursor)
+    projects_collection = client.active_user.get_projects(filter=filter)
     
     if not projects_collection or not projects_collection.items:
         logger.info(f"No projects found matching the search term: '{query}'")
@@ -600,7 +594,6 @@ async def get_model_versions(
     project_id: str,
     model_id: str,
     limit: int = 20,
-    cursor: str | None = None,
 ) -> str:
     """Get all versions for a specific model in a project.
     
@@ -608,16 +601,15 @@ async def get_model_versions(
         project_id: The ID of the Speckle project
         model_id: The ID of the model to retrieve versions for
         limit: Maximum number of versions to retrieve (default: 20)
-        cursor: Pagination cursor returned from a previous call
     """
     client = get_speckle_client()
     
     # Get versions for the specified model
     logger.info(
-        f"Retrieving versions for model {model_id} in project {project_id} (limit: {limit}, cursor: {cursor})"
+        f"Retrieving versions for model {model_id} in project {project_id} (limit: {limit})"
     )
     versions = client.version.get_versions(
-        model_id, project_id, limit=limit, cursor=cursor
+        model_id, project_id, limit=limit
     )
     
     if not versions or not versions.items:
@@ -652,7 +644,6 @@ async def get_version_objects(
     project_id: str,
     version_id: str,
     include_children: bool = False,
-    cursor: str | None = None,
 ) -> str:
     """Get objects from a specific version in a project.
     
@@ -660,13 +651,12 @@ async def get_version_objects(
         project_id: The ID of the Speckle project
         version_id: The ID of the version to retrieve objects from
         include_children: Whether to include children objects in the response
-        cursor: Pagination cursor returned from a previous call
     """
     client = get_speckle_client()
     
     # Get the version to access its referenced object ID
     logger.info(
-        f"Retrieving version {version_id} from project {project_id} (cursor: {cursor})"
+        f"Retrieving version {version_id} from project {project_id}"
     )
     version = client.version.get(version_id, project_id)
     
@@ -683,7 +673,7 @@ async def get_version_objects(
     
     # Receive the object
     logger.info(f"Receiving object {object_id}")
-    speckle_object = operations.receive(object_id, transport, cursor=cursor)
+    speckle_object = operations.receive(object_id, transport)
     
     # Convert the Speckle object to a serializable dictionary using the converter
     logger.info(f"Converting object to dictionary (include_children={include_children})")


### PR DESCRIPTION
## Summary
- drop cursor argument from server functions
- update HTTP wrapper to match new function signatures
- remove cursor usage from README
- simplify OpenAPI spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425236d5f08325b83b9b5f82a81d1c